### PR TITLE
Add phone number validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "doctrine/doctrine-bundle": "^2.14",
         "doctrine/doctrine-migrations-bundle": "^3.4",
         "doctrine/orm": "^3.3",
+        "giggsey/libphonenumber-for-php": "^9.0",
         "symfony/asset": "6.4.*",
         "symfony/console": "6.4.*",
         "symfony/dotenv": "6.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d22ab9bdf8c4efb71458e73bfe515f3c",
+    "content-hash": "59adbef1bdb70dbb204643dd73ec51b8",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -1287,6 +1287,138 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "giggsey/libphonenumber-for-php",
+            "version": "9.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/giggsey/libphonenumber-for-php.git",
+                "reference": "50c6e060642ea90e46e70b8ce96abfa8ded18b66"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/50c6e060642ea90e46e70b8ce96abfa8ded18b66",
+                "reference": "50c6e060642ea90e46e70b8ce96abfa8ded18b66",
+                "shasum": ""
+            },
+            "require": {
+                "giggsey/locale": "^2.7",
+                "php": "^8.1",
+                "symfony/polyfill-mbstring": "^1.31"
+            },
+            "replace": {
+                "giggsey/libphonenumber-for-php-lite": "self.version"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "friendsofphp/php-cs-fixer": "^3.71",
+                "infection/infection": "^0.28.0",
+                "nette/php-generator": "^4.1",
+                "php-coveralls/php-coveralls": "^2.7",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.7",
+                "phpstan/phpstan-deprecation-rules": "^2.0.1",
+                "phpstan/phpstan-phpunit": "^2.0.4",
+                "phpstan/phpstan-strict-rules": "^2.0.3",
+                "phpunit/phpunit": "^10.5.45",
+                "symfony/console": "^6.4",
+                "symfony/filesystem": "^6.4",
+                "symfony/process": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "libphonenumber\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Joshua Gigg",
+                    "email": "giggsey@gmail.com",
+                    "homepage": "https://giggsey.com/"
+                }
+            ],
+            "description": "A library for parsing, formatting, storing and validating international phone numbers, a PHP Port of Google's libphonenumber.",
+            "homepage": "https://github.com/giggsey/libphonenumber-for-php",
+            "keywords": [
+                "geocoding",
+                "geolocation",
+                "libphonenumber",
+                "mobile",
+                "phonenumber",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/giggsey/libphonenumber-for-php/issues",
+                "source": "https://github.com/giggsey/libphonenumber-for-php"
+            },
+            "time": "2025-03-28T09:51:44+00:00"
+        },
+        {
+            "name": "giggsey/locale",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/giggsey/Locale.git",
+                "reference": "1cd8b3ad2d43e04f4c2c6a240495af44780f809b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/giggsey/Locale/zipball/1cd8b3ad2d43e04f4c2c6a240495af44780f809b",
+                "reference": "1cd8b3ad2d43e04f4c2c6a240495af44780f809b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "friendsofphp/php-cs-fixer": "^3.66",
+                "pear/pear-core-minimal": "^1.10",
+                "pear/pear_exception": "^1.0",
+                "pear/versioncontrol_git": "^0.5",
+                "phing/phing": "^2.17.4",
+                "php-coveralls/php-coveralls": "^2.7",
+                "phpunit/phpunit": "^10.5.45",
+                "symfony/console": "^6.4",
+                "symfony/filesystem": "6.4",
+                "symfony/finder": "^6.4",
+                "symfony/process": "^6.4",
+                "symfony/var-exporter": "^6.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Giggsey\\Locale\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joshua Gigg",
+                    "email": "giggsey@gmail.com",
+                    "homepage": "https://giggsey.com/"
+                }
+            ],
+            "description": "Locale functions required by libphonenumber-for-php",
+            "support": {
+                "issues": "https://github.com/giggsey/Locale/issues",
+                "source": "https://github.com/giggsey/Locale/tree/2.8.0"
+            },
+            "time": "2025-03-20T14:25:27+00:00"
         },
         {
             "name": "psr/cache",

--- a/src/Command/ValidatePhoneCommand.php
+++ b/src/Command/ValidatePhoneCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\UserDelegateRequest;
+use App\Validator\Phone;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class ValidatePhoneCommand extends Command
+{
+    protected static $defaultName = 'app:validate:phone';
+    protected static $defaultDescription = 'Validates phone numbers in the database';
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private ValidatorInterface $validator
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        // Validate phone numbers
+        $requests = $this->entityManager->getRepository(UserDelegateRequest::class)->findAll();
+        $phoneConstraint = new Phone();
+        $invalidCount = 0;
+
+        foreach ($requests as $request) {
+            $violations = $this->validator->validate($request->getPhone(), $phoneConstraint);
+            if (count($violations) > 0) {
+                $invalidCount++;
+                $io->error(sprintf(
+                    'Invalid phone number found in UserDelegateRequest (ID: %d): %s',
+                    $request->getId(),
+                    $request->getPhone()
+                ));
+            }
+        }
+
+        if ($invalidCount > 0) {
+            $io->warning(sprintf('Validation completed. Found %d invalid phone numbers.', $invalidCount));
+            return Command::FAILURE;
+        }
+
+        $io->success('All phone numbers are valid.');
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/ValidatePhoneCommand.php
+++ b/src/Command/ValidatePhoneCommand.php
@@ -18,7 +18,7 @@ class ValidatePhoneCommand extends Command
 
     public function __construct(
         private EntityManagerInterface $entityManager,
-        private ValidatorInterface $validator
+        private ValidatorInterface $validator,
     ) {
         parent::__construct();
     }
@@ -35,7 +35,7 @@ class ValidatePhoneCommand extends Command
         foreach ($requests as $request) {
             $violations = $this->validator->validate($request->getPhone(), $phoneConstraint);
             if (count($violations) > 0) {
-                $invalidCount++;
+                ++$invalidCount;
                 $io->error(sprintf(
                     'Invalid phone number found in UserDelegateRequest (ID: %d): %s',
                     $request->getId(),
@@ -46,10 +46,12 @@ class ValidatePhoneCommand extends Command
 
         if ($invalidCount > 0) {
             $io->warning(sprintf('Validation completed. Found %d invalid phone numbers.', $invalidCount));
+
             return Command::FAILURE;
         }
 
         $io->success('All phone numbers are valid.');
+
         return Command::SUCCESS;
     }
 }

--- a/src/Entity/UserDelegateRequest.php
+++ b/src/Entity/UserDelegateRequest.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Repository\UserDelegateRequestRepository;
+use App\Validator\Phone;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -30,6 +31,7 @@ class UserDelegateRequest
     private ?User $user = null;
 
     #[ORM\Column(length: 50)]
+    #[Phone]
     private ?string $phone = null;
 
     #[ORM\ManyToOne(inversedBy: 'userDelegateRequests')]

--- a/src/Validator/Phone.php
+++ b/src/Validator/Phone.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute]
+class Phone extends Constraint
+{
+    public string $message = 'Broj telefona nije validan. Primeri validnih brojeva: 0651234567, 065123456, 0112345678';
+}

--- a/src/Validator/PhoneValidator.php
+++ b/src/Validator/PhoneValidator.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Validator;
+
+use libphonenumber\PhoneNumberUtil;
+use libphonenumber\NumberParseException;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class PhoneValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof Phone) {
+            throw new UnexpectedTypeException($constraint, Phone::class);
+        }
+
+        if (null === $value) {
+            return;
+        }
+
+        if (!is_string($value) || '' === $value) {
+            $this->context->buildViolation($constraint->message)
+                ->addViolation();
+            return;
+        }
+
+        if (!$this->validateSerbianPhoneNumber($value)) {
+            $this->context->buildViolation($constraint->message)
+                ->addViolation();
+        }
+    }
+
+    private function validateSerbianPhoneNumber(string $phoneNumber): bool
+    {
+        $phoneUtil = PhoneNumberUtil::getInstance();
+
+        try {
+            // Pre-validate: must be 9 or 10 digits starting with 0
+            if (!preg_match('/^0\d{8,9}$/', $phoneNumber)) {
+                return false;
+            }
+
+            // Convert to international format for libphonenumber
+            $phoneNumber = '+381' . substr($phoneNumber, 1);
+
+            $numberProto = $phoneUtil->parse($phoneNumber, 'RS');
+
+            return $phoneUtil->isValidNumberForRegion($numberProto, 'RS');
+        } catch (NumberParseException) {
+            return false;
+        }
+    }
+}

--- a/src/Validator/PhoneValidator.php
+++ b/src/Validator/PhoneValidator.php
@@ -2,8 +2,8 @@
 
 namespace App\Validator;
 
-use libphonenumber\PhoneNumberUtil;
 use libphonenumber\NumberParseException;
+use libphonenumber\PhoneNumberUtil;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -23,6 +23,7 @@ class PhoneValidator extends ConstraintValidator
         if (!is_string($value) || '' === $value) {
             $this->context->buildViolation($constraint->message)
                 ->addViolation();
+
             return;
         }
 
@@ -43,7 +44,7 @@ class PhoneValidator extends ConstraintValidator
             }
 
             // Convert to international format for libphonenumber
-            $phoneNumber = '+381' . substr($phoneNumber, 1);
+            $phoneNumber = '+381'.substr($phoneNumber, 1);
 
             $numberProto = $phoneUtil->parse($phoneNumber, 'RS');
 

--- a/tests/Validator/PhoneValidatorTest.php
+++ b/tests/Validator/PhoneValidatorTest.php
@@ -4,9 +4,9 @@ namespace App\Tests\Validator;
 
 use App\Validator\Phone;
 use App\Validator\PhoneValidator;
-use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 

--- a/tests/Validator/PhoneValidatorTest.php
+++ b/tests/Validator/PhoneValidatorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Tests\Validator;
+
+use App\Validator\Phone;
+use App\Validator\PhoneValidator;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class PhoneValidatorTest extends TestCase
+{
+    private PhoneValidator $validator;
+    private MockObject&ExecutionContextInterface $context;
+    private MockObject&ConstraintViolationBuilderInterface $violationBuilder;
+
+    protected function setUp(): void
+    {
+        $this->validator = new PhoneValidator();
+
+        // Create mock objects using createMock()
+        $this->violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->context = $this->createMock(ExecutionContextInterface::class);
+
+        // Set up the violation builder mock
+        $this->violationBuilder->method('addViolation')
+            ->willReturn(null);
+
+        // Set up the context mock
+        $this->context->method('buildViolation')
+            ->willReturn($this->violationBuilder);
+
+        $this->validator->initialize($this->context);
+    }
+
+    #[DataProvider('validPhoneNumbersProvider')]
+    public function testValidPhoneNumbers(string $phoneNumber): void
+    {
+        $constraint = new Phone();
+
+        $this->context->expects($this->never())
+            ->method('buildViolation');
+
+        $this->validator->validate($phoneNumber, $constraint);
+    }
+
+    #[DataProvider('invalidPhoneNumbersProvider')]
+    public function testInvalidPhoneNumbers(mixed $phoneNumber): void
+    {
+        $constraint = new Phone();
+
+        $this->context->expects($this->once())
+            ->method('buildViolation')
+            ->with($constraint->message)
+            ->willReturn($this->violationBuilder);
+
+        $this->validator->validate($phoneNumber, $constraint);
+    }
+
+    public static function validPhoneNumbersProvider(): array
+    {
+        return [
+            ['0651234567'],    // 10-digit mobile number
+            ['065123456'],     // 9-digit mobile number
+            ['0111234567'],    // Belgrade landline
+            ['0654545656'],    // From fixtures
+        ];
+    }
+
+    public static function invalidPhoneNumbersProvider(): array
+    {
+        return [
+            ['06512'],        // Too short
+            ['0651234567890'], // Too long
+            ['1651234567'],   // Doesn't start with 0
+            ['065abcdefg'],   // Contains letters
+            [''],             // Empty string
+            [12345],         // Not a string
+            ['0651234 56'],  // Contains space
+            ['065-123456'],  // Contains dash
+            ['+381651234567'], // International format not allowed
+        ];
+    }
+
+    public function testNullIsValid(): void
+    {
+        $constraint = new Phone();
+
+        $this->context->expects($this->never())
+            ->method('buildViolation');
+
+        $this->validator->validate(null, $constraint);
+    }
+}


### PR DESCRIPTION
Closes #48


Radim prvo jedan regex check da forsiramo 0651234567 format: `/^0\d{8,9}$/`

A posle dodatno ovaj lib: https://github.com/giggsey/libphonenumber-for-php

Rules za Srbiju:
https://github.com/giggsey/libphonenumber-for-php/blob/50c6e060642ea90e46e70b8ce96abfa8ded18b66/src/data/PhoneNumberMetadata_RS.php#L21 

Valjda je to ok 🤔

___

Dodao sam komandu, pa kad se importuje produkciona baza, mozemo da proverimo da li stari unosi prolaze validaciju:

```bash
❯ docker exec solidarity-php-container php bin/console app:validate:phone

 [OK] All phone numbers are valid. 
```

Dodacu slicnu komandu i za racun (mod 97) na tom PR.