### PR TITLE
Change admin tables design (name/email)

### DIFF
--- a/templates/admin/delegate/list.html.twig
+++ b/templates/admin/delegate/list.html.twig
@@ -33,7 +33,7 @@
             {% for delegate in delegates.items %}
                 <tr class="hover:bg-base-200">
                     <td>
-                        <div>{{ delegate.fullName }}</div>
+                        <div>{{ delegate.fullName ?? user.username }}</div>
                         <a href="{{ path('admin_user_edit', { 'id': delegate.id }) }}" class="link link-primary link-hover">
                             {{ delegate.email }}
                         </a>

--- a/templates/admin/delegate/list.html.twig
+++ b/templates/admin/delegate/list.html.twig
@@ -33,12 +33,10 @@
             {% for delegate in delegates.items %}
                 <tr class="hover:bg-base-200">
                     <td>
-                        <div>
-                            <a href="{{ path('admin_user_edit', {'id': delegate.id}) }}" class="link link-hover">
-                                {{ delegate.fullName }}
-                            </a>
-                        </div>
-                        <div class="text-sm text-gray-500">{{ delegate.email }}</div>
+                        <div>{{ delegate.fullName }}</div>
+                        <a href="{{ path('admin_user_edit', { 'id': delegate.id }) }}" class="link link-primary link-hover">
+                            {{ delegate.email }}
+                        </a>
                     </td>
                     <td>{{ delegate.userDelegateSchools|length }}</td>
                     <td>

--- a/templates/admin/delegate/list.html.twig
+++ b/templates/admin/delegate/list.html.twig
@@ -19,10 +19,6 @@
                         Ime
                     </th>
                     <th>
-                        <span class="ti ti-mail text-xl"></span>
-                        Email
-                    </th>
-                    <th>
                         <span class="ti ti-link text-xl"></span>
                         Povezanih škola
                     </th>
@@ -36,8 +32,14 @@
             <tbody>
             {% for delegate in delegates.items %}
                 <tr class="hover:bg-base-200">
-                    <td>{{ delegate.fullName }}</td>
-                    <td>{{ delegate.email }}</td>
+                    <td>
+                        <div>
+                            <a href="{{ path('admin_user_edit', {'id': delegate.id}) }}" class="link link-hover">
+                                {{ delegate.fullName }}
+                            </a>
+                        </div>
+                        <div class="text-sm text-gray-500">{{ delegate.email }}</div>
+                    </td>
                     <td>{{ delegate.userDelegateSchools|length }}</td>
                     <td>
                         {{ delegate.createdAt|date('d.m.Y.') }}

--- a/templates/admin/donor/list.html.twig
+++ b/templates/admin/donor/list.html.twig
@@ -36,12 +36,10 @@
             {% for donor in donors.items %}
                 <tr class="hover:bg-base-200">
                     <td>
-                        <div>
-                            <a href="{{ path('admin_user_edit', {'id': donor.user.id}) }}" class="link link-hover">
-                                {{ donor.user.fullName ?? donor.user.username }}
-                            </a>
-                        </div>
-                        <div class="text-sm text-gray-500">{{ donor.user.email }}</div>
+                        <div>{{ donor.user.fullName ?? donor.user.username }}</div>
+                        <a href="{{ path('admin_user_edit', { 'id': donor.user.id }) }}" class="link link-primary link-hover">
+                            {{ donor.user.email }}
+                        </a>
                     </td>
                     <td>
                         {% if donor.isMonthly %}

--- a/templates/admin/donor/list.html.twig
+++ b/templates/admin/donor/list.html.twig
@@ -19,10 +19,6 @@
                         Ime
                     </th>
                     <th>
-                        <span class="ti ti-mail text-xl"></span>
-                        Email
-                    </th>
-                    <th>
                         <span class="ti ti-repeat text-xl"></span>
                         Mesečna podrška
                     </th>
@@ -39,8 +35,14 @@
             <tbody>
             {% for donor in donors.items %}
                 <tr class="hover:bg-base-200">
-                    <td>{{ donor.user.fullName ?? donor.user.username }}</td>
-                    <td>{{ donor.user.email }}</td>
+                    <td>
+                        <div>
+                            <a href="{{ path('admin_user_edit', {'id': donor.user.id}) }}" class="link link-hover">
+                                {{ donor.user.fullName ?? donor.user.username }}
+                            </a>
+                        </div>
+                        <div class="text-sm text-gray-500">{{ donor.user.email }}</div>
+                    </td>
                     <td>
                         {% if donor.isMonthly %}
                             <div class="status status-success mb-1"></div>

--- a/templates/admin/transaction/list.html.twig
+++ b/templates/admin/transaction/list.html.twig
@@ -42,12 +42,10 @@
             {% for transaction in transactions.items %}
                 <tr class="hover:bg-base-200">
                     <td>
-                        <div>
-                            <a href="{{ path('admin_user_edit', {'id': transaction.user.id}) }}" class="link link-hover">
-                                {{ transaction.user.fullName }}
-                            </a>
-                        </div>
-                        <div class="text-sm text-gray-500">{{ transaction.user.email }}</div>
+                        <div>{{ transaction.user.fullName }}</div>
+                        <a href="{{ path('admin_user_edit', { 'id': transaction.user.id }) }}" class="link link-primary link-hover">
+                            {{ transaction.user.email }}
+                        </a>
                     </td>
                     <td>{{ transaction.educator.name }}</td>
                     <td>{{ transaction.accountNumber }}</td>

--- a/templates/admin/transaction/list.html.twig
+++ b/templates/admin/transaction/list.html.twig
@@ -42,7 +42,7 @@
             {% for transaction in transactions.items %}
                 <tr class="hover:bg-base-200">
                     <td>
-                        <div>{{ transaction.user.fullName }}</div>
+                        <div>{{ transaction.user.fullName ?? user.username }}</div>
                         <a href="{{ path('admin_user_edit', { 'id': transaction.user.id }) }}" class="link link-primary link-hover">
                             {{ transaction.user.email }}
                         </a>

--- a/templates/admin/transaction/list.html.twig
+++ b/templates/admin/transaction/list.html.twig
@@ -41,7 +41,14 @@
             <tbody>
             {% for transaction in transactions.items %}
                 <tr class="hover:bg-base-200">
-                    <td>{{ transaction.user.fullName }}</td>
+                    <td>
+                        <div>
+                            <a href="{{ path('admin_user_edit', {'id': transaction.user.id}) }}" class="link link-hover">
+                                {{ transaction.user.fullName }}
+                            </a>
+                        </div>
+                        <div class="text-sm text-gray-500">{{ transaction.user.email }}</div>
+                    </td>
                     <td>{{ transaction.educator.name }}</td>
                     <td>{{ transaction.accountNumber }}</td>
                     <td>{{ transaction.amount|number_format }}</td>

--- a/templates/admin/user/list.html.twig
+++ b/templates/admin/user/list.html.twig
@@ -37,12 +37,10 @@
                     <tr class="hover:bg-base-200">
                         <th>{{ user.id }}</th>
                         <td>
-                            <div>
-                                <a href="{{ path('admin_user_edit', {'id': user.id}) }}" class="link link-hover">
-                                    {{ user.fullName }}
-                                </a>
-                            </div>
-                            <div class="text-sm text-gray-500">{{ user.email }}</div>
+                            <div>{{ user.fullName }}</div>
+                            <a href="{{ path('admin_user_edit', { 'id': user.id }) }}" class="link link-primary link-hover">
+                                {{ user.email }}
+                            </a>
                         </td>
                         <td>{{ user.getRoles|roleTranslate }}</td>
                         <td>

--- a/templates/admin/user/list.html.twig
+++ b/templates/admin/user/list.html.twig
@@ -37,7 +37,7 @@
                     <tr class="hover:bg-base-200">
                         <th>{{ user.id }}</th>
                         <td>
-                            <div>{{ user.fullName }}</div>
+                            <div>{{ user.fullName ?? user.username }}</div>
                             <a href="{{ path('admin_user_edit', { 'id': user.id }) }}" class="link link-primary link-hover">
                                 {{ user.email }}
                             </a>

--- a/templates/admin/user/list.html.twig
+++ b/templates/admin/user/list.html.twig
@@ -20,10 +20,6 @@
                         Ime
                     </th>
                     <th>
-                        <span class="ti ti-mail text-xl"></span>
-                        Email
-                    </th>
-                    <th>
                         <span class="ti ti-military-rank text-xl"></span>
                         Privilegija
                     </th>
@@ -40,8 +36,14 @@
                 {% for user in users.items %}
                     <tr class="hover:bg-base-200">
                         <th>{{ user.id }}</th>
-                        <td>{{ user.fullName }}</td>
-                        <td>{{ user.email }}</td>
+                        <td>
+                            <div>
+                                <a href="{{ path('admin_user_edit', {'id': user.id}) }}" class="link link-hover">
+                                    {{ user.fullName }}
+                                </a>
+                            </div>
+                            <div class="text-sm text-gray-500">{{ user.email }}</div>
+                        </td>
                         <td>{{ user.getRoles|roleTranslate }}</td>
                         <td>
                             {{ user.createdAt|date('d.m.Y.') }}

--- a/templates/admin/userDelegateRequest/list.html.twig
+++ b/templates/admin/userDelegateRequest/list.html.twig
@@ -21,10 +21,6 @@
                         Ime
                     </th>
                     <th>
-                        <span class="ti ti-mail text-xl"></span>
-                        Email
-                    </th>
-                    <th>
                         <span class="ti ti-phone text-xl"></span>
                         Broj telefona
                     </th>
@@ -46,8 +42,14 @@
             <tbody>
             {% for userDelegateRequest in userDelegateRequests.items %}
                 <tr class="hover:bg-base-200">
-                    <td>{{ userDelegateRequest.user.fullName }}</td>
-                    <td>{{ userDelegateRequest.user.email }}</td>
+                    <td>
+                        <div>
+                            <a href="{{ path('admin_user_edit', {'id': userDelegateRequest.user.id}) }}" class="link link-hover">
+                                {{ userDelegateRequest.user.fullName }}
+                            </a>
+                        </div>
+                        <div class="text-sm text-gray-500">{{ userDelegateRequest.user.email }}</div>
+                    </td>
                     <td>{{ userDelegateRequest.phone }}</td>
                     <td>{{ userDelegateRequest.city.name }}</td>
                     <td>{{ userDelegateRequest.school.name }}</td>

--- a/templates/admin/userDelegateRequest/list.html.twig
+++ b/templates/admin/userDelegateRequest/list.html.twig
@@ -43,12 +43,10 @@
             {% for userDelegateRequest in userDelegateRequests.items %}
                 <tr class="hover:bg-base-200">
                     <td>
-                        <div>
-                            <a href="{{ path('admin_user_edit', {'id': userDelegateRequest.user.id}) }}" class="link link-hover">
-                                {{ userDelegateRequest.user.fullName }}
-                            </a>
-                        </div>
-                        <div class="text-sm text-gray-500">{{ userDelegateRequest.user.email }}</div>
+                        <div>{{ userDelegateRequest.user.fullName }}</div>
+                        <a href="{{ path('admin_user_edit', { 'id': userDelegateRequest.user.id }) }}" class="link link-primary link-hover">
+                            {{ userDelegateRequest.user.email }}
+                        </a>
                     </td>
                     <td>{{ userDelegateRequest.phone }}</td>
                     <td>{{ userDelegateRequest.city.name }}</td>


### PR DESCRIPTION
Closes #72

![image](https://github.com/user-attachments/assets/90da3e95-2347-40e2-aa67-2abbedfe6a9f)

Ovako je na svim navedenim stranama osim na:

http://localhost:1000/admin/transaction/list

Tu nemamo name/email kombinaciju:
![image](https://github.com/user-attachments/assets/f763c593-b609-47f4-8f8f-d3b0d0f2ecac)

