### PR TITLE
Fixes: Mod97Validator always throw error

### DIFF
--- a/src/Form/EducatorEditType.php
+++ b/src/Form/EducatorEditType.php
@@ -40,7 +40,7 @@ class EducatorEditType extends AbstractType
             ->add('amount', IntegerType::class, [
                 'label' => 'Cifra',
             ])
-            ->add('accountNumber', IntegerType::class, [
+            ->add('accountNumber', TextType::class, [
                 'label' => 'Broj računa',
             ])
             ->add('submit', SubmitType::class, [


### PR DESCRIPTION
Closes #102

1. Broj računa je bio prosleđivan kao string (npr. "265104031000361092")
2. Polje obrasca je definisano kao IntegerType, zbog čega je PHP konvertovao broj u integer
3. Zbog PHP-ovih ograničenja za integer, velika vrednost broja je bila izmenjena tokom ove konverzije
4. Sada sa TextType, broj će ostati kao string tokom celog procesa, čuvajući njegovu tačnu vrednost

---

Testovi su bili dobri, zato sto je bug nastajao kod forme, ma mislim da ovaj fix takodje:

Closes #103