### PR TITLE
Feature/flexible-account-number-input

### DIFF
--- a/src/DataFixtures/EducatorFixtures.php
+++ b/src/DataFixtures/EducatorFixtures.php
@@ -30,11 +30,11 @@ class EducatorFixtures extends Fixture implements FixtureGroupInterface
     private function generateAccountNumber(): string
     {
         // Generate base number (160 is bank code for Banca Intesa)
-        $base = '160'.str_pad(mt_rand(0, 9999999999), 10, '0', STR_PAD_LEFT);
+        // We need a 16-digit number (18 total - 2 control digits)
+        $base = '160'.str_pad(mt_rand(0, 9999999999), 13, '0', STR_PAD_LEFT);
 
         // Calculate control digits using MOD97
-        $num = (int) substr($base, 0, -2);
-        $controlNumber = 98 - ($num * 100) % 97;
+        $controlNumber = 98 - ((int) $base % 97);
 
         // Format final number with control digits
         return $base.str_pad($controlNumber, 2, '0', STR_PAD_LEFT);

--- a/src/Form/DataTransformer/AccountNumberTransformer.php
+++ b/src/Form/DataTransformer/AccountNumberTransformer.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Form\DataTransformer;
+
+use Symfony\Component\Form\DataTransformerInterface;
+
+class AccountNumberTransformer implements DataTransformerInterface
+{
+    public function transform($value): mixed
+    {
+        if (null === $value) {
+            return '';
+        }
+
+        return $value;
+    }
+
+    public function reverseTransform($value): mixed
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        // Remove any dashes from the account number
+        $cleanNumber = str_replace('-', '', $value);
+
+        // If length is less than 18, pad with zeros after the first 3 digits
+        if (strlen($cleanNumber) < 18) {
+            $prefix = substr($cleanNumber, 0, 3);
+            $rest = substr($cleanNumber, 3);
+            $paddedRest = str_pad($rest, 15, '0', STR_PAD_LEFT);
+            $cleanNumber = $prefix.$paddedRest;
+        }
+
+        return $cleanNumber;
+    }
+}

--- a/src/Form/DataTransformer/AccountNumberTransformer.php
+++ b/src/Form/DataTransformer/AccountNumberTransformer.php
@@ -21,17 +21,27 @@ class AccountNumberTransformer implements DataTransformerInterface
             return null;
         }
 
-        // Remove any dashes from the account number
-        $cleanNumber = str_replace('-', '', $value);
+        $numbersOnly = preg_replace('/\D/', '', $value);
 
-        // If length is less than 18, pad with zeros after the first 3 digits
-        if (strlen($cleanNumber) < 18) {
-            $prefix = substr($cleanNumber, 0, 3);
-            $rest = substr($cleanNumber, 3);
-            $paddedRest = str_pad($rest, 15, '0', STR_PAD_LEFT);
-            $cleanNumber = $prefix.$paddedRest;
+        if (18 === strlen($numbersOnly)) {
+            return $numbersOnly;
         }
 
-        return $cleanNumber;
+        $parts = [
+            substr($numbersOnly, 0, 3),
+            substr($numbersOnly, 3, -2),
+            substr($numbersOnly, -2),
+        ];
+
+        if (strlen($parts[1]) < 13) {
+            $parts[1] = str_pad(
+                $parts[1],
+                13,
+                '0',
+                STR_PAD_LEFT
+            );
+        }
+
+        return join('', $parts);
     }
 }

--- a/src/Form/EducatorEditType.php
+++ b/src/Form/EducatorEditType.php
@@ -40,7 +40,7 @@ class EducatorEditType extends AbstractType
             ->add('amount', IntegerType::class, [
                 'label' => 'Cifra',
             ])
-            ->add('accountNumber', IntegerType::class, [
+            ->add('accountNumber', TextType::class, [
                 'label' => 'Broj računa',
             ])
             ->add('submit', SubmitType::class, [

--- a/src/Form/EducatorEditType.php
+++ b/src/Form/EducatorEditType.php
@@ -4,6 +4,7 @@ namespace App\Form;
 
 use App\Entity\Educator;
 use App\Entity\School;
+use App\Form\DataTransformer\AccountNumberTransformer;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
@@ -16,6 +17,13 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class EducatorEditType extends AbstractType
 {
+    private AccountNumberTransformer $accountNumberTransformer;
+
+    public function __construct()
+    {
+        $this->accountNumberTransformer = new AccountNumberTransformer();
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -46,6 +54,8 @@ class EducatorEditType extends AbstractType
             ->add('submit', SubmitType::class, [
                 'label' => 'Sačuvaj',
             ]);
+
+        $builder->get('accountNumber')->addModelTransformer($this->accountNumberTransformer);
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/tests/Form/DataTransformer/AccountNumberTransformerTest.php
+++ b/tests/Form/DataTransformer/AccountNumberTransformerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Tests\Form\DataTransformer;
+
+use App\Form\DataTransformer\AccountNumberTransformer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class AccountNumberTransformerTest extends TestCase
+{
+    private AccountNumberTransformer $transformer;
+
+    protected function setUp(): void
+    {
+        $this->transformer = new AccountNumberTransformer();
+    }
+
+    #[DataProvider('transformProvider')]
+    public function testTransform(?string $input, string $expected): void
+    {
+        $this->assertEquals($expected, $this->transformer->transform($input));
+    }
+
+    #[DataProvider('reverseTransformProvider')]
+    public function testReverseTransform(?string $input, ?string $expected): void
+    {
+        $this->assertEquals($expected, $this->transformer->reverseTransform($input));
+    }
+
+    public static function transformProvider(): array
+    {
+        return [
+            'null value returns empty string' => [null, ''],
+            'string value returns unchanged' => ['265104031000361092', '265104031000361092'],
+        ];
+    }
+
+    public static function reverseTransformProvider(): array
+    {
+        return [
+            'null value returns null' => [null, null],
+            // Test cases with dashes
+            'account with dashes 1' => ['160-462754-78', '160000000046275478'],
+            'account with dashes 2' => ['325-950050-02', '325000000095005002'],
+            // Test cases without dashes but needs padding
+            'account without dashes needs padding 1' => ['16046275478', '160000000046275478'],
+            'account without dashes needs padding 2' => ['32595005002', '325000000095005002'],
+            // Already properly formatted numbers
+            'already 18 digits 1' => ['265104031000361092', '265104031000361092'],
+            'already 18 digits 2' => ['150000002501288698', '150000002501288698'],
+        ];
+    }
+}

--- a/tests/Form/DataTransformer/AccountNumberTransformerTest.php
+++ b/tests/Form/DataTransformer/AccountNumberTransformerTest.php
@@ -39,12 +39,15 @@ class AccountNumberTransformerTest extends TestCase
     {
         return [
             'null value returns null' => [null, null],
-            // Test cases with dashes
-            'account with dashes 1' => ['160-462754-78', '160000000046275478'],
-            'account with dashes 2' => ['325-950050-02', '325000000095005002'],
-            // Test cases without dashes but needs padding
-            'account without dashes needs padding 1' => ['16046275478', '160000000046275478'],
-            'account without dashes needs padding 2' => ['32595005002', '325000000095005002'],
+            // Test cases with special characters and spaces
+            'account with dashes' => ['160-462754-78', '160000000046275478'],
+            'account with dashes and spaces' => ['160 - 462754 - 78', '160000000046275478'],
+            'account with multiple spaces' => ['325  950050  02', '325000000095005002'],
+            'account with special characters' => ['160.462754#78', '160000000046275478'],
+            'account with mixed characters' => ['160--462.754..78', '160000000046275478'],
+            // Test cases without special characters but needs padding
+            'account without special chars needs padding 1' => ['16046275478', '160000000046275478'],
+            'account without special chars needs padding 2' => ['32595005002', '325000000095005002'],
             // Already properly formatted numbers
             'already 18 digits 1' => ['265104031000361092', '265104031000361092'],
             'already 18 digits 2' => ['150000002501288698', '150000002501288698'],


### PR DESCRIPTION
Racuni Banca Intese su cesto u kracem obliku (160-462754-78) i tipicno bankarski software sam dodaje nule posle trece cifre, ili imaju 3 odvojena input fielda.
Takodje, neko bi mozda uneo i crtice, lako je na backend strani ih ukloniti.

Potreban je fleksibilan sistem koji prihvata sve ove formate i ne smara usera forsirajuci ga da unosi specifican format, ali čuva podatke u standardizovanom obliku.

Takodje mod 97 validacija ne funkcionise ako imamo manje od 18 cifara.


Šta je urađeno:
1. Dodat `AccountNumberTransformer` koji:
   * Prihvata račune sa ili bez crtica (koje uklanja) i duzine manje od 18 karaktera (npr. "160-462754-78" ili "16046275478").
   * Automatski dodaje nule nakon prve tri cifre do ukupno 18 karaktera
   * Normalizuje sve račune u jedinstven format za čuvanje u bazi (18 chars)

Primer:

```javascript
Unos: 160-462754-78
Čuvanje u bazi: 160000000046275478

Unos: 16046275478
Čuvanje u bazi: 160000000046275478

Unos: 160000000046275478
Čuvanje u bazi: 160000000046275478
```