### PR TITLE
Correct property name in repository join query

### DIFF
--- a/src/Repository/TransactionRepository.php
+++ b/src/Repository/TransactionRepository.php
@@ -28,31 +28,31 @@ class TransactionRepository extends ServiceEntityRepository
 
         if (!empty($criteria['donor'])) {
             $qb->leftJoin('t.user', 'u')
-               ->andWhere('u.email LIKE :donor')
-               ->setParameter('donor', '%'.$criteria['donor'].'%');
+                ->andWhere('u.email LIKE :donor')
+                ->setParameter('donor', '%'.$criteria['donor'].'%');
         }
 
-        $qb->leftJoin('t.educator', 'e')
-           ->leftJoin('e.school', 's');
+        $qb->leftJoin('t.damagedEducator', 'e')
+            ->leftJoin('e.school', 's');
 
         if (!empty($criteria['educator'])) {
             $qb->andWhere('e.name LIKE :educator')
-               ->setParameter('educator', '%'.$criteria['educator'].'%');
+                ->setParameter('educator', '%'.$criteria['educator'].'%');
         }
 
         if (isset($criteria['school'])) {
             $qb->andWhere('e.school = :school')
-               ->setParameter('school', $criteria['school']);
+                ->setParameter('school', $criteria['school']);
         }
 
         if (isset($criteria['city'])) {
             $qb->andWhere('s.city = :city')
-               ->setParameter('city', $criteria['city']);
+                ->setParameter('city', $criteria['city']);
         }
 
         if (isset($criteria['status'])) {
             $qb->andWhere('t.status = :status')
-               ->setParameter('status', $criteria['status']);
+                ->setParameter('status', $criteria['status']);
         }
 
         // Set the sorting


### PR DESCRIPTION
Problem:
U upitu za listanje transakcija u TransactionRepository-ju (http://localhost:1000/admin/transaction/list) koristi se pogrešan naziv property-ja 't.educator' umesto 't.damagedEducator', što uzrokuje 500 error:

"SELECT t FROM App\Entity\Transaction t LEFT JOIN t.educator e LEFT JOIN e.school s ORDER BY t.id DESC"

Rešenje:
Izmena join klauzule u TransactionRepository-ju da koristi ispravan naziv property-ja 't.damagedEducator' koji je definisan u Transaction entitetu.