### PR TITLE
Prevent DataFixtures to mark regular user as delegate

### DIFF
--- a/src/DataFixtures/DamagedEducatorFixtures.php
+++ b/src/DataFixtures/DamagedEducatorFixtures.php
@@ -87,6 +87,25 @@ class DamagedEducatorFixtures extends Fixture implements FixtureGroupInterface
         $schools = $this->entityManager->getRepository(School::class)->findAll();
         $periods = $this->entityManager->getRepository(DamagedEducatorPeriod::class)->findAll();
 
+        // Ensure at least one DamagedEducator for delegat@gmail.com, their school, and the active period
+        $coreDelegate = $this->entityManager->getRepository(User::class)->findOneBy(['email' => 'delegat@gmail.com']);
+        $activePeriod = $this->entityManager->getRepository(DamagedEducatorPeriod::class)->findOneBy(['active' => true]);
+        $userDelegateSchool = null;
+        if ($coreDelegate && $activePeriod) {
+            $userDelegateSchool = $this->entityManager->getRepository(\App\Entity\UserDelegateSchool::class)
+                ->findOneBy(['user' => $coreDelegate]);
+            if ($userDelegateSchool) {
+                $educator = new DamagedEducator();
+                $educator->setName($this->generateName());
+                $educator->setSchool($userDelegateSchool->getSchool());
+                $educator->setAmount(Amounts::generate(30000, null, 15, 50000));
+                $educator->setAccountNumber($this->generateAccountNumber());
+                $educator->setPeriod($activePeriod);
+                $educator->setCreatedBy($coreDelegate);
+                $manager->persist($educator);
+            }
+        }
+
         foreach ($schools as $school) {
             // Generate 1-30 educators per school
             $count = mt_rand(1, 30);

--- a/src/DataFixtures/UserDelegateSchoolFixtures.php
+++ b/src/DataFixtures/UserDelegateSchoolFixtures.php
@@ -3,7 +3,6 @@
 namespace App\DataFixtures;
 
 use App\Entity\School;
-use App\Entity\User;
 use App\Entity\UserDelegateSchool;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
@@ -21,13 +20,18 @@ class UserDelegateSchoolFixtures extends Fixture implements FixtureGroupInterfac
         // Set fixed seed for deterministic results
         mt_srand(1234);
 
-        // Get all delegates
-        $delegates = $this->entityManager->getRepository(User::class)
-            ->createQueryBuilder('u')
-            ->where('u.roles LIKE :role')
-            ->setParameter('role', '%ROLE_DELEGATE%')
+        // Get all delegates with confirmed delegate requests
+        $confirmedRequests = $this->entityManager->getRepository(\App\Entity\UserDelegateRequest::class)
+            ->createQueryBuilder('r')
+            ->where('r.status = :status')
+            ->setParameter('status', \App\Entity\UserDelegateRequest::STATUS_CONFIRMED)
             ->getQuery()
             ->getResult();
+
+        $delegates = [];
+        foreach ($confirmedRequests as $request) {
+            $delegates[] = $request->getUser();
+        }
 
         // Get all schools
         $schools = $this->entityManager->getRepository(School::class)->findAll();


### PR DESCRIPTION
Closes #129

Odradio sam jos par fixeva ovo ovih testova oko delegata:

- Ranije je uzeto 5 usera i dodeljen im je role delegata, a sad se prave novi useri samo da bi bili delegati. Tu je i dolazilo do buga.
- Povecan broj delegata sa 5 na 10 + delegat@gmail.com koji ima 'specijalan' status.
- Samo potvrdjenim delegatima su random dodeljene 1-3 skole. Ranije je i rejected delegat mogao biti uvezan sa skolom.


