### PR TITLE
Add templated cron job for app:cancelled-transaction command

### DIFF
--- a/ansible/tasks/app_setup.yml
+++ b/ansible/tasks/app_setup.yml
@@ -85,3 +85,12 @@
     - var
     - public
   tags: [deploy]
+
+- name: Deploy cron job for cancelled transactions
+  ansible.builtin.template:
+    src: templates/etc/cron.d/cancelled-transaction.j2
+    dest: /etc/cron.d/cancelled-transaction
+    owner: root
+    group: root
+    mode: "0644"
+  tags: [deploy]

--- a/ansible/templates/etc/cron.d/cancelled-transaction.j2
+++ b/ansible/templates/etc/cron.d/cancelled-transaction.j2
@@ -1,0 +1,1 @@
+0 * * * * www-data cd {{ app_root }} && php bin/console app:cancelled-transaction --env={{ app_env }} --no-interaction 2>&1 | logger -t cancelled-transaction-cron


### PR DESCRIPTION
Close #214 

Rezultat se loguje u syslog, pa se moze uvek doci do logova prethonih runova sa: `journalctl -t cancelled-transaction-cron`.

Testirao sam sa delayom od 1 min:

```bash
root@ubuntu-s-1vcpu-2gb-70gb-intel-fra1-01:~# journalctl -t cancelled-transaction-cron
Apr 23 21:05:01 ubuntu-s-1vcpu-2gb-70gb-intel-fra1-01 cancelled-transaction-cron[70642]: 
Apr 23 21:05:01 ubuntu-s-1vcpu-2gb-70gb-intel-fra1-01 cancelled-transaction-cron[70642]: Command started at 2025-04-23 21:05:01
Apr 23 21:05:01 ubuntu-s-1vcpu-2gb-70gb-intel-fra1-01 cancelled-transaction-cron[70642]: --------------------------------------
Apr 23 21:05:01 ubuntu-s-1vcpu-2gb-70gb-intel-fra1-01 cancelled-transaction-cron[70642]: 
Apr 23 21:05:01 ubuntu-s-1vcpu-2gb-70gb-intel-fra1-01 cancelled-transaction-cron[70642]:  [OK] Command finished at 2025-04-23 21:05:01
Apr 23 21:05:01 ubuntu-s-1vcpu-2gb-70gb-intel-fra1-01 cancelled-transaction-cron[70642]: 
Apr 23 21:06:01 ubuntu-s-1vcpu-2gb-70gb-intel-fra1-01 cancelled-transaction-cron[70726]: 
Apr 23 21:06:01 ubuntu-s-1vcpu-2gb-70gb-intel-fra1-01 cancelled-transaction-cron[70726]: Command started at 2025-04-23 21:06:01
Apr 23 21:06:01 ubuntu-s-1vcpu-2gb-70gb-intel-fra1-01 cancelled-transaction-cron[70726]: --------------------------------------
Apr 23 21:06:01 ubuntu-s-1vcpu-2gb-70gb-intel-fra1-01 cancelled-transaction-cron[70726]: 
Apr 23 21:06:01 ubuntu-s-1vcpu-2gb-70gb-intel-fra1-01 cancelled-transaction-cron[70726]:  [OK] Command finished at 2025-04-23 21:06:01
Apr 23 21:06:01 ubuntu-s-1vcpu-2gb-70gb-intel-fra1-01 cancelled-transaction-cron[70726]: 

```