### PR TITLE
VerifyEmailExceptionInterface exceptions translated (#310)

### DIFF
--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -12,6 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use SymfonyCasts\Bundle\VerifyEmail\Exception\VerifyEmailExceptionInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class RegistrationController extends AbstractController
 {
@@ -77,7 +78,7 @@ class RegistrationController extends AbstractController
     }
 
     #[Route('/email-verifikacija', name: 'verify_email')]
-    public function verifyUserEmail(Request $request, UserRepository $userRepository, UserDonorRepository $userDonorRepository, Security $security): Response
+    public function verifyUserEmail(Request $request, UserRepository $userRepository, UserDonorRepository $userDonorRepository, Security $security, TranslatorInterface $translator): Response
     {
         $userId = $request->get('id');
         if (!$userId) {
@@ -107,7 +108,7 @@ class RegistrationController extends AbstractController
                 return $this->redirectToRoute('delegate_request_success');
             }
         } catch (VerifyEmailExceptionInterface $exception) {
-            $this->addFlash('error', $exception->getReason());
+            $this->addFlash('error', $translator->trans($exception->getReason()));
 
             return $this->redirectToRoute('login');
         }

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -38,3 +38,7 @@ TransactionCancelled: Otkazana
 
 DamagedEducatorNew: Aktivan
 DamagedEducatorDeleted: Obrisan
+
+The link to verify your email has expired. Please request a new link.: Link za verifikaciju vašeg email-a je istekao. Zatražite novi link.
+The link to verify your email is invalid. Please request a new link.: Link za verifikaciju vašeg email-a nije validan. Zatražite novi link.
+The link to verify your email appears to be for a different account or email. Please request a new link.: Link za verifikaciju vašeg email-a je za drugi nalog ili email. Zatražite novi link.


### PR DESCRIPTION
Injected Translator into RegistrationController:verifyUserEmail.
Added messages for 3 exceptions into messages.en.yaml.
![image](https://github.com/user-attachments/assets/dcfc7672-b0a3-41f8-afc1-1d5d67fb6777)
